### PR TITLE
v0.2.5 Liftie policy update

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,30 @@
 # Change log for module cdp-prerequisite for Azure
 
+## v0.2.5 AWS policy adjustment
+- Liftie policy wasn't sufficient. Adding below policies base on testing. These policies are missing in Liftie policy V9, V10, V12.
+```
+                "iam:AddRoleToInstanceProfile",
+                "iam:AttachRolePolicy",
+                "iam:CreateRole",
+                "iam:CreateServiceLinkedRole",
+                "iam:DeleteRole",
+                "iam:DeleteRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:GetRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListRolePolicies",
+                "iam:ListRoles",
+                "iam:PassRole",
+                "iam:PutRolePolicy",
+                "iam:SimulatePrincipalPolicy"
+
+                "iam:CreateInstanceProfile",
+                "iam:DeleteInstanceProfile",
+                "iam:ListInstanceProfiles",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:AddRoleToInstanceProfile" 
+```
+
 ## v0.2.4 AWS modules first version
 - AWS modules first version
 - a minor fix for Azure module

--- a/aws/data-services-prerequisites/policies/aws-ds-restricted-policy-1.json
+++ b/aws/data-services-prerequisites/policies/aws-ds-restricted-policy-1.json
@@ -210,7 +210,20 @@
                 "iam:ListRoleTags",
                 "iam:RemoveRoleFromInstanceProfile",
                 "iam:TagRole",
-                "iam:UntagRole"
+                "iam:AddRoleToInstanceProfile",
+                "iam:AttachRolePolicy",
+                "iam:CreateRole",
+                "iam:CreateServiceLinkedRole",
+                "iam:DeleteRole",
+                "iam:DeleteRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:GetRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListRolePolicies",
+                "iam:ListRoles",
+                "iam:PassRole",
+                "iam:PutRolePolicy",
+                "iam:SimulatePrincipalPolicy"
             ],
             "Resource": [
                 "*"
@@ -245,7 +258,12 @@
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "iam:GetRole",
                 "iam:ListRoles",
-                "iam:GetInstanceProfile"
+                "iam:GetInstanceProfile",
+                "iam:CreateInstanceProfile",
+                "iam:DeleteInstanceProfile",
+                "iam:ListInstanceProfiles",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:AddRoleToInstanceProfile"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
## v0.2.5 AWS policy adjustment
- Liftie policy wasn't sufficient. Adding below policies base on testing. These policies are missing in Liftie policy V9, V10, V12.
```
                "iam:AddRoleToInstanceProfile",
                "iam:AttachRolePolicy",
                "iam:CreateRole",
                "iam:CreateServiceLinkedRole",
                "iam:DeleteRole",
                "iam:DeleteRolePolicy",
                "iam:DetachRolePolicy",
                "iam:GetRole",
                "iam:ListAttachedRolePolicies",
                "iam:ListRolePolicies",
                "iam:ListRoles",
                "iam:PassRole",
                "iam:PutRolePolicy",
                "iam:SimulatePrincipalPolicy"

                "iam:CreateInstanceProfile",
                "iam:DeleteInstanceProfile",
                "iam:ListInstanceProfiles",
                "iam:RemoveRoleFromInstanceProfile",
                "iam:AddRoleToInstanceProfile" 
```