### PR TITLE
0.2.8 Azure CMK module update

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,7 @@
 # Change log for module cdp-prerequisite for Azure
+## v0.2.8 Azure module
+- RBAC for current caller to the new created KeyVault. If not granted, the key cannot be created due to insufficient permissions.
+- Add a `test` folder to custom-role-permission module, cause it will be frequently used.
 ## v0.2.7 Azure permission module change base on doc update.
 - remove  `"Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write"` for environment.
 - Add `"Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/*"` permission for Liftie. 

--- a/azure/cdp-custom-role-permissions/test/main.tf
+++ b/azure/cdp-custom-role-permissions/test/main.tf
@@ -1,0 +1,17 @@
+module "custom_role_permissions" {
+  source          = "../"
+  enable_cmk      = true
+  enable_dw       = false
+  enable_liftie   = true
+  enable_de       = false
+}
+
+output "spn_permissions" {
+  value = module.custom_role_permissions.spn_permissions
+}
+output "mi_permissions" {
+  value = module.custom_role_permissions.mi_permissions
+}
+output "dns_zone_permissions" {
+  value = module.custom_role_permissions.dns_zone_permissions
+}


### PR DESCRIPTION
## v0.2.8 Azure module
- RBAC for current caller to the new created KeyVault. If not granted, the key cannot be created due to insufficient permissions.
- Add a `test` folder to custom-role-permission module, cause it will be frequently used.