### PR TITLE
Update AWS cross-account reduced policy with Liftie permissions

### DIFF
--- a/aws/xaccount-role/policies/cdp-cross-account-reduced-policy.json
+++ b/aws/xaccount-role/policies/cdp-cross-account-reduced-policy.json
@@ -119,6 +119,7 @@
           "ec2:DescribeAccountAttributes",
           "ec2:DisassociateAddress",
           "ec2:DescribeNetworkInterfaces",
+          "ec2:CreateTags",
           "sts:DecodeAuthorizationMessage",
           "cloudformation:DescribeStacks",
           "iam:ListInstanceProfiles",
@@ -150,6 +151,8 @@
           "iam:GetInstanceProfile",
           "iam:SimulatePrincipalPolicy",
           "iam:GetRole",
+          "iam:TagRole",
+          "iam:UntagRole",
           "rds:AddTagsToResource",
           "rds:CreateDBInstance",
           "rds:CreateDBSubnetGroup",
@@ -183,6 +186,22 @@
           "iam:PassRole"
         ],
         "Resource": "*"
+      },
+      {
+        "Sid": "IdentityAccessManagementLiftie",
+        "Effect": "Allow",
+        "Action": [
+          "iam:GetRolePolicy",
+          "iam:PutRolePolicy",
+          "iam:CreateInstanceProfile",
+          "iam:DeleteInstanceProfile",
+          "iam:AddRoleToInstanceProfile",
+          "iam:RemoveRoleFromInstanceProfile"
+        ],
+        "Resource": [
+          "arn:aws:iam::*:role/liftie-*",
+          "arn:aws:iam::*:instance-profile/liftie-*"
+        ]
       },
       {
         "Sid": "IdentityAccessManagementLimited",


### PR DESCRIPTION
## Summary
- Add `ec2:CreateTags` to the existing permissions block
- Add `iam:TagRole` and `iam:UntagRole` to the existing permissions block
- Add new `IdentityAccessManagementLiftie` statement with scoped permissions for `liftie-*` roles and instance profiles (`iam:GetRolePolicy`, `iam:PutRolePolicy`, `iam:CreateInstanceProfile`, `iam:DeleteInstanceProfile`, `iam:AddRoleToInstanceProfile`, `iam:RemoveRoleFromInstanceProfile`)

## Test plan
- [ ] Run `terraform init` and `terraform plan` in `aws/xaccount-role/` to validate the updated policy JSON
- [ ] Verify the policy JSON is valid and matches expected Liftie requirements