### PR TITLE
v0.3.1 Azure encryption and rbac

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,9 @@
 # Change log for module cdp-prerequisite for Azure
+## v0.3.1 Azure encryption and rbac
+- #43 deprecate access policy restriction when providing an existing KeyVault
+- #40 Move storage encryption out from CMK module
+- #42 Use variable rather than calculation in RBAC for service principal RBAC.
+- Remove the caluclation for not assigning KV, DNS Zone, VNET related roles when these resources are in the same subscription as the primary subscription and the primary RBAC is already at subscription level. These calculations are reasonable, but too complex for users to understand. Instead, assign the permissions regardless. 
 ## v0.3.0 Azure RBAC redesign
 ### Major change idea
 - https://github.com/nicknameyu/cdp-prerequisite-module/issues/36#issuecomment-4403511459

--- a/azure/cmk-prerequisites/cmk.tf
+++ b/azure/cmk-prerequisites/cmk.tf
@@ -5,19 +5,21 @@ data "azurerm_key_vault" "kv" {
   count               = var.create_keyvault ? 0:1
   name                = var.key_vault_name
   resource_group_name = var.resource_group_name
-  lifecycle {
-    postcondition {
-      condition     = ! self.rbac_authorization_enabled 
-      error_message = "Key Vault must be configured with Access Policy for authorization."
-    }
-  }
+}
+resource "azurerm_resource_group" "kv" {
+  count    = var.create_resource_group ? 1:0
+  name     = var.resource_group_name
+  provider = azurerm.kv
+  location = var.location
+  tags     = var.tags
 }
 resource "azurerm_key_vault" "kv" {
-  count                      = var.create_keyvault ? 1:0
+  count                      = var.create_resource_group || var.create_keyvault ? 1:0
   name                       = var.key_vault_name
   location                   = var.location
+  provider                   = azurerm.kv
   rbac_authorization_enabled = ! var.enable_access_policy
-  resource_group_name        = var.resource_group_name
+  resource_group_name        = var.create_resource_group ? azurerm_resource_group.kv[0].name : var.resource_group_name
   tenant_id                  = data.azurerm_subscription.current.tenant_id
   sku_name                   = "premium"
   soft_delete_retention_days = 7
@@ -35,12 +37,14 @@ locals {
 resource "azurerm_role_assignment" "caller" {
   count                = var.create_keyvault ? 1:0
   principal_id         = data.azurerm_client_config.current.object_id
+  provider             = azurerm.kv
   role_definition_name = "Key Vault Crypto Officer"
   scope                = azurerm_key_vault.kv[0].id
 }
 ### Create CMK
 resource "azurerm_key_vault_key" "default" {
   name         = var.key_name
+  provider     = azurerm.kv
   key_vault_id = local.key_vault_id
   key_type     = "RSA"
   key_size     = 2048
@@ -72,10 +76,3 @@ output "cmk_key_vault_id" {
   value = var.create_keyvault ? azurerm_key_vault.kv[0].id : data.azurerm_key_vault.kv[0].id
 }
 
-#### Change the storage account setting
-resource "azurerm_storage_account_customer_managed_key" "cdp" {
-  for_each                  = var.storage_account_ids
-  storage_account_id        = each.value
-  key_vault_key_id          = azurerm_key_vault_key.default.id
-  user_assigned_identity_id = var.managed_identity_id
-}

--- a/azure/cmk-prerequisites/provider.tf
+++ b/azure/cmk-prerequisites/provider.tf
@@ -2,3 +2,8 @@
 
 data azurerm_subscription "current"{}
 data "azurerm_client_config" "current" {}
+provider "azurerm" {
+  alias           = "kv"
+  subscription_id = var.subscription_id
+  features {}
+}

--- a/azure/cmk-prerequisites/variables.tf
+++ b/azure/cmk-prerequisites/variables.tf
@@ -19,10 +19,15 @@ variable "tags" {
 }
 
 ############### Key Vault resource variables ###############
+variable "create_resource_group" {
+  type = bool
+  default = false
+  description = "Flag to control whether to create a resource group."
+}
 variable "create_keyvault" {
   type    = bool
   default = true
-  description = "Switch for whether to create the Key Vault. "
+  description = "Switch for whether to create the Key Vault. Force creating key vault when `create_resource_group` is true."
 }
 
 variable "key_vault_name" {
@@ -59,10 +64,6 @@ variable "managed_identity_id" {
     condition     = var.enable_access_policy == false || (var.enable_access_policy == true && var.managed_identity_id != null)
     error_message = "managed_identity_id cannot be null or empty when enable_access_policy is true."
   }
-  validation {
-    condition     = var.storage_account_ids == null || (var.storage_account_ids != null && var.managed_identity_id != null)
-    error_message = "managed_identity_id cannot be null or empty when storage_account_id is not null. Cause storage account CMK encryption must be configured with a managed identity."
-  }
 }
 
 
@@ -78,9 +79,3 @@ variable "enable_access_policy" {
   description = "Control whether to create access policy."
 }
 
-#############
-variable "storage_account_ids" {
-  type = map(string)
-  default = {}
-  description = "The IDs of the storeage account to be encrypted with the CMK. When provided, the storage account will be configured with CMK encryption."
-}

--- a/azure/service-principal/dns-zone-role-assignment.tf
+++ b/azure/service-principal/dns-zone-role-assignment.tf
@@ -1,21 +1,27 @@
 // DNS Zone RBAC must be at least be assigned at resource group level, because there are multiple private DNS zones in a CDP deployment.
 
 locals {
-  dns_zone_subscription_id = var.private_dns_zone_resource_group_id == null ? null : split("/", var.private_dns_zone_resource_group_id)[2]
-  // If `private_dns_zone_resource_group_id` is not provided, do not need this role assignment.
-  // If `private_dns_zone_resource_group_id` is in the same subscription as the CDP subscription, and the RBAC is at subscription level, do not need this role assignment.
-  dns_zone_assignment      = var.private_dns_zone_resource_group_id == null ? {} : (
-                                  local.scope_level == "SUBSCRIPTION" && local.subscription_id == local.dns_zone_subscription_id ? {}:local.principals)
+  dns_zone_subscription_id = var.dns_zone_subscription_id == null ? data.azurerm_subscription.current.subscription_id : var.dns_zone_subscription_id
 }
 provider "azurerm" {
   alias           = "dns_zone"
-  subscription_id = var.private_dns_zone_resource_group_id == null ? local.subscription_id : local.dns_zone_subscription_id
+  subscription_id = local.dns_zone_subscription_id
   features {}
 }
-resource "azurerm_role_assignment" "dns_zone" {
-  for_each             = local.dns_zone_assignment
+resource "azurerm_role_assignment" "spn_dns_zone" {
+  count                = var.private_dns_zone_resource_group_id == null ? 0 : (
+    length(var.rbac_scope) == 0 && (data.azurerm_subscription.current.subscription_id == local.dns_zone_subscription_id ) ? 0:1)
   provider             = azurerm.dns_zone
-  principal_id         = each.value
+  principal_id         = var.spn_object_id
+  scope                = var.private_dns_zone_resource_group_id
+  role_definition_name = "Private DNS Zone Contributor"
+}
+
+resource "azurerm_role_assignment" "mi_dns_zone" {
+  count                = var.private_dns_zone_resource_group_id == null || var.mi_object_id == null ? 0 : (
+    length(var.rbac_scope) == 0 && (data.azurerm_subscription.current.subscription_id == local.dns_zone_subscription_id ) ? 0:1)
+  provider             = azurerm.dns_zone
+  principal_id         = var.mi_object_id
   scope                = var.private_dns_zone_resource_group_id
   role_definition_name = "Private DNS Zone Contributor"
 }

--- a/azure/service-principal/kv-role-assignment.tf
+++ b/azure/service-principal/kv-role-assignment.tf
@@ -1,21 +1,24 @@
 locals {
-
-  kv_subscription_id = var.key_vault_id == null ? null : split("/", var.key_vault_id)[2]
-  // If `key_vault_id` is not provided, do not need this role assignment.
-  // If `key_vault_id` is in the same subscription as the CDP subscription, and the RBAC is at subscription level, do not need this role assignment.
-  kv_assignment      = var.key_vault_id == null ? {} : (
-                                  local.scope_level == "SUBSCRIPTION" && local.subscription_id == local.kv_subscription_id ? {}:local.principals)
+  kv_subscription_id = var.kv_subscription_id == null ? data.azurerm_subscription.current.subscription_id : var.kv_subscription_id
 }
 provider "azurerm" {
   alias           = "kv"
-  subscription_id = var.key_vault_id == null ? local.subscription_id : local.kv_subscription_id
+  subscription_id = local.kv_subscription_id
   features {}
 }
-resource "azurerm_role_assignment" "kv" {
-  for_each             = local.kv_assignment
-  principal_id         = each.value
+
+resource "azurerm_role_assignment" "spn_kv" {
+  count                = var.key_vault_id == null ? 0 : 1
+  principal_id         = var.spn_object_id
   provider             = azurerm.kv
   scope                = var.key_vault_id
   role_definition_name = "Key Vault Crypto Service Encryption User"
 }
 
+resource "azurerm_role_assignment" "mi_kv" {
+  count                = var.key_vault_id == null || var.mi_object_id == null ? 0 : 1
+  principal_id         = var.mi_object_id
+  provider             = azurerm.kv
+  scope                = var.key_vault_id
+  role_definition_name = "Key Vault Crypto Service Encryption User"
+}

--- a/azure/service-principal/role-assignment.tf
+++ b/azure/service-principal/role-assignment.tf
@@ -1,12 +1,17 @@
+data "azurerm_subscription" "current" {}
+
 locals {
+  principals = merge({ spn = var.spn_object_id }, var.mi_object_id == null ? {} : { mi = var.mi_object_id } )
+  rbac_scope = length(var.rbac_scope) == 0 ? {sub = data.azurerm_subscription.current.id} : var.rbac_scope
   role_assignments = {
-    for pair in setproduct(keys(local.principals), keys(local.scope)) :
+    for pair in setproduct(keys(local.principals), keys(local.rbac_scope)) :
     "${pair[0]}__${pair[1]}" => {
       principal_id = local.principals[pair[0]]
-      scope        = local.scope[pair[1]]
+      scope        = local.rbac_scope[pair[1]]
     }
   }
 }
+
 resource "azurerm_role_assignment" "cdp" {
   for_each             = local.role_assignments
   scope                = each.value.scope
@@ -36,7 +41,7 @@ module "custom_role_permissions" {
 resource "azurerm_role_definition" "reduced" {
   count       = var.create_custom_role ? 1:0
   name        = var.custom_role_name
-  scope       = "/subscriptions/${local.subscription_id}"
+  scope       = "/subscriptions/${data.azurerm_subscription.current.subscription_id}"
   description = "Custom role for CDP provisioning with reduced permission."
 
 
@@ -46,6 +51,6 @@ resource "azurerm_role_definition" "reduced" {
   }
 
   assignable_scopes = [
-    "/subscriptions/${local.subscription_id}", # /subscriptions/00000000-0000-0000-0000-000000000000
+    data.azurerm_subscription.current.id
   ]
 }

--- a/azure/service-principal/variables.tf
+++ b/azure/service-principal/variables.tf
@@ -65,6 +65,20 @@ variable "enable_liftie" {
   description = "Enable Liftie permissions. Default to false because contributor permission is default setting."
 }
 
+## Subscription IDs for KeyVault and private DNS zone.
+## Theoretically speaking, these subscription IDs can be calculated by the `key_vault_id`, `scope`, and `private_dns_zone_resource_group_id` variables. But in some circumstances, these
+## variables are generated from output of other resources, which make it impossible for terraform to calculate the value in this module at the planning stage. 
+variable "kv_subscription_id" {
+  type = string
+  default = null
+  description = "Key Vault subscription ID. Default to null. When set to `null`, the key vault is in the same subscription with the CDP resources."
+}
+variable "dns_zone_subscription_id" {
+  type = string
+  default = null
+  description = "Private DNS zone subscription ID. Default to null. When set to `null`, the private DNS zone resource group is in the same subscription with the CDP resources."
+}
+
 ## Permissions on supporting resources.
 variable "key_vault_id" {
   type = string
@@ -85,45 +99,33 @@ variable "private_dns_zone_resource_group_id" {
 }
 
 ## Scope and permission calculation
-variable "scope" {
   // The reason of designing this variable as a map is: there is the possibility that a customer may split the environment resources in two resource groups, 
-  // one for prerequisite, and the other for compute resources. There are too many prerequisites resources in current environment setup. One resoruce group makes it very messy for administration purpose. 
-  type = map(string)
-  description = "Map of Azure subscription or resource groups for this module to assign the RBAC to."
-  validation {
-    condition = length(var.scope) <= 1 || length(distinct([
-      for id in values(var.scope) :
-      regex("/subscriptions/([^/]+)", lower(id))[0]
-    ])) == 1
-    error_message = "All resource IDs in 'scope' must belong to the same Azure subscription."
-  }
+  // one for prerequisite, and the other for compute resources. There are too many prerequisites resources in current environment setup. One resoruce group 
+  // makes it very messy for administration purpose. 
+variable "rbac_scope" {
+  type        = map(string)
+  default     = {}
+  description = "Map of Azure resource group IDs for this module to assign the RBAC to. When empty, RBAC at subscription level."
+
   validation {
     condition = alltrue([
-      for id in values(var.scope) :
-      can(regex("^/subscriptions/[^/]+$", lower(id))) ||
-      can(regex("^/subscriptions/[^/]+/resourcegroups/[^/]+$", lower(id)))
+      for v in values(var.rbac_scope) :
+      can(regex(
+        "^/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/resourceGroups/[^/]+$",
+        v
+      ))
     ])
-    error_message = "All values in 'scope' must be either a subscription resource ID (/subscriptions/<id>) or a resource group resource ID (/subscriptions/<id>/resourceGroups/<name>)."
-  }
-}
-
-
-locals {
-  principals = merge({ spn = local.spn_object_id }, var.mi_object_id == null ? {} : { mi = var.mi_object_id } )
-  subscription_id = regex("/subscriptions/([^/]+)", lower(values(var.scope)[0]))[0]
-  /*
-  Calculate scope and scope level base on var.scope. If one of the elements is subscription ID, then ignore everything else, assign two values: one is local.scope_level = "SUBSCRIPTION", 
-  the other is the local.scope = {cdp = <the subscription ID>}; otherwise, the local.scope_level = "RESOURCEGROUP",  local.scope = var.scope.
-  */
-  subscription_ids = {
-    for key, id in var.scope :
-    key => id
-    if can(regex("^/subscriptions/[^/]+$", lower(id)))
+    error_message = "All values must be valid Azure resource group IDs in the format: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}."
   }
 
-  scope_level = length(local.subscription_ids) > 0 ? "SUBSCRIPTION" : "RESOURCEGROUP"
-
-  scope = local.scope_level == "SUBSCRIPTION" ? {
-    cdp = "/subscriptions/${local.subscription_id}"
-  } : var.scope
+  validation {
+    condition = length(distinct([
+      for v in values(var.rbac_scope) :
+      regex(
+        "/subscriptions/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/",
+        v
+      )[0]
+    ])) <= 1
+    error_message = "All resource groups must belong to the same subscription."
+  }
 }

--- a/azure/service-principal/vnet-role-assignment.tf
+++ b/azure/service-principal/vnet-role-assignment.tf
@@ -22,12 +22,12 @@ locals {
   # - Subscription level if force_sub_rbac is true (DS enabled + MI in use)
   # - Subscription level if vnet_resource_group_id is null (no RG scoping possible)
   # - Otherwise, use the provided resource group
-  vnet_rbac_scope = (local.force_sub_rbac || var.vnet_resource_group_id == null) ? "/subscriptions/${local.subscription_id}" : var.vnet_resource_group_id
+  vnet_rbac_scope = (local.force_sub_rbac || var.vnet_resource_group_id == null) ? data.azurerm_subscription.current.id : var.vnet_resource_group_id
 
   # Skip VNET assignment entirely when scope_level is SUBSCRIPTION, because
   # SPN and MI already received network permissions at subscription level via
   # the broader scope assignment — no additional VNET assignment needed.
-  vnet_assignment = local.scope_level == "SUBSCRIPTION" ? {} : local.principals
+  vnet_assignment = length(var.rbac_scope) == 0 ? {} : local.principals
 }
 resource "azurerm_role_assignment" "vnet" {
   for_each             = local.vnet_assignment

--- a/azure/storage-encryption/README.MD
+++ b/azure/storage-encryption/README.MD
@@ -1,0 +1,84 @@
+# storage encryption
+
+Terraform module that applies **Customer-Managed Key (CMK) encryption** to one or more Azure Storage Accounts using an Azure Key Vault key and a User-Assigned Managed Identity.
+
+## Design idea
+### why the storage encryption must be an independent module
+**Considerations:**
+- The CMK and key vault are created in the [cmk-prerequisites](../cmk-prerequisites/) module. In real customer practice, this is usually created by Cloud Admin team independently from DataScience team.
+- The encryption MI is created in the [env-prerequisites](../env-prerequisites/) module. 
+- The RBAC for the MI is granted in the [service-principal](../service-principal/) module, because the MI and the SPN need to share the same permissions for several different resources.
+
+**Design Challenges:**
+- The storage encryption cannot be done in `cmk-prerequisites` module, because `cmk-prerequisites` module is supposed to be independent. 
+- The storage encryption cannot be done in `env-prerequisites` module, because the RBAC has not been done yet.
+- The storage encryption cannot be done in `service-principal` module, because it doesn't align with the purpose of `service-principal` module.
+
+### Is it worth while to have such a simple module?
+The entire repo gives the users a impression that it is designed to complete all the prerequisites settings. If this module is not provided, the users will easily miss this piece in the practice.
+
+
+---
+
+## Usage
+
+```hcl
+module "storage_cmk" {
+  source = "./modules/storage-encryption"
+
+  storage_account_ids = {
+    cdp = "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Storage/storageAccounts/primary"
+    nfs = "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Storage/storageAccounts/secondary"
+  }
+
+  key_vault_key_id    = azurerm_key_vault_key.cmk.id
+  managed_identity_id = azurerm_user_assigned_identity.storage.id
+}
+```
+
+---
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| azurerm | >= 3.0.0 |
+
+---
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_storage_account_customer_managed_key.cdp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_customer_managed_key) | resource |
+
+---
+
+## Inputs
+
+| Name | Description | Type | Required |
+|------|-------------|------|----------|
+| `storage_account_ids` | A map of logical names to Storage Account resource IDs to be encrypted. | `map(string)` | yes |
+| `key_vault_key_id` | The ID of the Azure Key Vault Key used for encryption. | `string` | yes |
+| `managed_identity_id` | The resource ID of the User-Assigned Managed Identity used for Key Vault access. | `string` | yes |
+
+---
+
+## Prerequisites
+
+The following must be in place **before** applying this module:
+
+1. **Key Vault access policy / RBAC** — the User-Assigned Managed Identity must have at least `Key Vault Crypto Service Encryption User` permissions (RBAC) or an access policy granting `get`, `wrapKey`, and `unwrapKey` on the target Key Vault.
+
+2. **Storage Account identity assignment** — each Storage Account must have the User-Assigned Managed Identity associated with it before this module runs. This is typically done via `identity { type = "UserAssigned"; identity_ids = [...] }` on the `azurerm_storage_account` resource.
+
+3. **Soft-delete & purge protection** — the Key Vault must have both soft-delete and purge protection enabled, which is an Azure requirement for CMK-encrypted storage.
+
+---
+
+## Notes
+
+- The module uses `for_each` over the `storage_account_ids` map, so each entry is managed as an independent resource. Adding or removing entries will only affect the corresponding storage account.
+- Destroying this module will remove the CMK association and revert the storage accounts to Microsoft-managed keys (MMK); **it will not delete the storage accounts themselves**.
+- Key rotation is handled automatically by Azure when the Key Vault key is rotated, provided the key version is omitted from `key_vault_key_id` (i.e., use the versionless key URI).

--- a/azure/storage-encryption/main.tf
+++ b/azure/storage-encryption/main.tf
@@ -1,0 +1,18 @@
+variable "storage_account_ids" {
+  type = map(string)
+  description = "A map of storage account IDs to be encrypted."
+}
+variable "key_vault_key_id" {
+  type = string
+  description = "Auzre Key Vault Key ID"
+}
+variable "managed_identity_id" {
+  type = string
+  description = "Managed identity ID for the encryption"
+}
+resource "azurerm_storage_account_customer_managed_key" "cdp" {
+  for_each                  = var.storage_account_ids
+  storage_account_id        = each.value
+  key_vault_key_id          = var.key_vault_key_id
+  user_assigned_identity_id = var.managed_identity_id
+}


### PR DESCRIPTION
close #40 
close #42 
close #40 
- #43 deprecate access policy restriction when providing an existing KeyVault
- #40 Move storage encryption out from CMK module
- #42 Use variable rather than calculation in RBAC for service principal RBAC.
- Remove the caluclation for not assigning KV, DNS Zone, VNET related roles when these resources are in the same subscription as the primary subscription and the primary RBAC is already at subscription level. These calculations are reasonable, but too complex for users to understand. Instead, assign the permissions regardless. 